### PR TITLE
fix-sidebar-navigation-arrow

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-link.tsx
+++ b/features/layout/sidebar-navigation/menu-item-link.tsx
@@ -32,6 +32,7 @@ export const Anchor = styled(Link)`
   color: ${color("gray", 100)};
   text-decoration: none;
 `;
+// transform: ${({ isCollapsed }) => (isCollapsed ? "scaleX(-1)" : "none")}
 
 export const Icon = styled.img`
   width: ${space(6)};
@@ -48,7 +49,7 @@ export function MenuItemLink({
   return (
     <ListItem isActive={isActive}>
       <Anchor href={href}>
-        <Icon src={iconSrc} alt={`${text} icon`} /> {!isCollapsed && text}
+        {<Icon src={iconSrc} alt={`${text} icon`} />} {!isCollapsed && text}{" "}
       </Anchor>
     </ListItem>
   );

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -145,6 +145,7 @@ const LinkList = styled(List)`
 `;
 
 const CollapseMenuItem = styled(MenuItemButton)`
+  transform: ${({ isCollapsed }) => (isCollapsed ? "scaleX(-1)" : "none")};
   display: none;
 
   @media (min-width: ${breakpoint("desktop")}) {
@@ -197,7 +198,7 @@ export function SidebarNavigation() {
             />
             <CollapseMenuItem
               text="Collapse"
-              iconSrc="/icons/arrow-left.svg"
+              iconSrc={"/icons/arrow-left.svg"}
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
             />


### PR DESCRIPTION
When the sidebar navigation is collapsed the arrow of the “Collapse” button now points to the right.
